### PR TITLE
Locations are not being included in the serialized response if they only have a single field in the location object, e.g. just geo_location

### DIFF
--- a/plugin.rb
+++ b/plugin.rb
@@ -30,7 +30,7 @@ after_initialize do
   add_to_serializer(:topic_view, :location) { object.topic.custom_fields['location'] }
   add_to_serializer(:topic_view, :include_location?) do
     location = object.topic.custom_fields['location']
-    location && location.length >= 2
+    location && location.length >= 1
   end
 
   TopicList.preloaded_custom_fields << 'location' if TopicList.respond_to? :preloaded_custom_fields


### PR DESCRIPTION
Fixes #3 

I've only ever dabbled in ruby and I'm not sure what you were trying to accomplish with the location.length >= 2 check. This might be related to the other issue where things are objects now rather than strings.