### PR TITLE
FIX: z-index issue with post counts on avatar

### DIFF
--- a/assets/stylesheets/common/locations.scss
+++ b/assets/stylesheets/common/locations.scss
@@ -296,7 +296,7 @@ input.input-location, div.input-location {
     border-radius: 4px;
   }
 
-  .btn-map, .avatar, .leaflet-control, .map-title, .search {
+  .btn-map, .avatar, .post-count, .leaflet-control, .map-title, .search {
     z-index: 99;
     border: 1px solid dark-light-diff($primary, $secondary, 80%, -65%) !important;
   }


### PR DESCRIPTION
Avatars were being shown on top of the post counts in the collapsed topic map

Before: 
<img width="129" alt="screen shot 2017-11-27 at 1 42 33 pm" src="https://user-images.githubusercontent.com/1681963/33283275-440cfa74-d379-11e7-9b61-7713d955c10e.png">

After:
<img width="131" alt="screen shot 2017-11-27 at 1 42 52 pm" src="https://user-images.githubusercontent.com/1681963/33283280-47fbbcb0-d379-11e7-9e7f-9e677292bcee.png">
